### PR TITLE
Fix race in feed item updates

### DIFF
--- a/tests/core/test_feed_item_id_stability.py
+++ b/tests/core/test_feed_item_id_stability.py
@@ -1,0 +1,27 @@
+import tempfile
+import os
+import pytest
+from models import init_db, get_db, FeedModel, FeedItemModel
+
+@pytest.fixture
+def temp_db():
+    import models
+    with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as tmp:
+        tmp_db = tmp.name
+    original_db = models.DB_PATH
+    models.DB_PATH = tmp_db
+    init_db()
+    yield tmp_db
+    models.DB_PATH = original_db
+    if os.path.exists(tmp_db):
+        os.unlink(tmp_db)
+
+
+def test_item_id_stable_on_update(temp_db):
+    feed_id = FeedModel.create_feed("https://example.com", "Example")
+    first_id = FeedItemModel.create_item(feed_id, "guid", "Title", "https://example.com/1")
+    second_id = FeedItemModel.create_item(feed_id, "guid", "Updated Title", "https://example.com/1")
+    assert first_id == second_id
+    with get_db() as conn:
+        row = conn.execute("SELECT title FROM feed_items WHERE id=?", (first_id,)).fetchone()
+        assert row[0] == "Updated Title"


### PR DESCRIPTION
## Summary
- preserve feed item IDs by updating existing rows instead of replacing them
- add regression test ensuring feed item IDs remain stable across updates

## Testing
- `python -m pytest tests/core/ -n auto --dist=loadfile -v`
- `./run_all_tests.sh --section ui` *(fails: BrowserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68c3be253174832aa007dd1e45b19818